### PR TITLE
fix(ci): align pnpm version with lockfile for frozen install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ jobs:
           node-version: 22
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@11.9.0",
   "devDependencies": {
     "typescript": "^5.9.3",
     "vitepress": "^2.0.0-alpha.17",


### PR DESCRIPTION
## Summary

修复合并 #18 后 **Build and deploy** workflow 失败的问题。

**根因：** CI 使用 pnpm 9，而 lockfile 由 pnpm 11 生成（overrides 配置在 pnpm-workspace.yaml 中）。执行 pnpm install --frozen-lockfile 时触发 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH。

**修复：**
- 在 package.json 中声明 `packageManager: pnpm@11.9.0`
- deploy.yml 中移除 pnpm 9 版本锁定，由 pnpm/action-setup 自动读取 packageManager 字段

## Test plan

- [x] `pnpm install --frozen-lockfile` — 通过
- [x] `pnpm run docs:build` — 构建成功

Made with [Cursor](https://cursor.com)