### PR TITLE
chore(ci): upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.repository == 'doocs/coding-interview'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@1.5.0
         with:
           githubToken: ${{ secrets.ACTION_TOKEN }}
           compressOnly: true
@@ -36,6 +36,6 @@ jobs:
       - name: Push Changes
         if: |
           steps.calibre.outputs.markdown != ''
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1.3.0
         with:
           github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,29 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v6
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -43,7 +31,7 @@ jobs:
         run: echo "interview.doocs.org" > docs/.vitepress/dist/CNAME
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -59,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,14 +12,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 
       - name: Prettify code
-        uses: creyD/prettier_action@v3.3
+        uses: creyD/prettier_action@v4.6
         with:
-          prettier_options: --write **/*.{md}
+          file_pattern: "**/*.md"
+          prettier_options: --write
           commit_message: "style: prettify code"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

升级所有 workflow 中的 GitHub Actions 至最新稳定主版本，并修复相关兼容问题。

| Action | 旧版本 | 新版本 |
|--------|--------|--------|
| actions/checkout | v4 | **v7** |
| actions/setup-node | v4 | **v6** |
| pnpm/action-setup | v4 (pnpm 9) | **v6**（读取 packageManager） |
| actions/cache | v4 | 移除，改用 setup-node 内置 pnpm cache |
| actions/upload-pages-artifact | v3 | **v5** |
| actions/deploy-pages | v4 | **v5** |
| creyD/prettier_action | v3.3 | **v4.6** |
| calibreapp/image-actions | @main | **@1.5.0** |
| ad-m/github-push-action | @master | **@v1.3.0** |

其他修复：
- 在 `package.json` 中声明 `packageManager: pnpm@11.9.0`，解决 lockfile overrides 与 CI pnpm 版本不一致的问题
- `prettier_action` v4.6 将 `file_pattern` 与 `prettier_options` 分离，修复 `**/*.{md}` 匹配失败

## Test plan

- [x] `pnpm install --frozen-lockfile` — 通过
- [x] `pnpm run docs:build` — 构建成功
- [ ] 合并后确认 Build and deploy / Prettier workflow 通过

Made with [Cursor](https://cursor.com)