### PR TITLE
chore: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary

- `actions/setup-node` `v6` → `v7`

Other workflow actions are already current.

## Test plan

- [ ] Confirm the GitHub Pages deploy workflow still starts on `main`

Made with [Cursor](https://cursor.com)